### PR TITLE
Docker: Use Alpine instead of Ubuntu

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -15,8 +15,18 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install clang-format
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 11
+          rm llvm.sh
+          sudo apt-get install -y --no-install-recommends clang-format-11
+
       - name: Format files
-        run: find src include -type f -a \( -name "*.cc" -o -name "*.h" \) -print0 | xargs -0 clang-format-9 -i
+        run: find src include -type f -a \( -name "*.cc" -o -name "*.h" \) -print0 | xargs -0 clang-format-11 -i
 
       - name: Check for differences
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,7 +226,7 @@ target_compile_definitions(ppr-benchmark PRIVATE ${ppr-compile-definitions})
 ################################
 # clang-format check
 ################################
-find_program(CLANG_FORMAT_COMMAND NAMES clang-format-9 clang-format-8 clang-format)
+find_program(CLANG_FORMAT_COMMAND NAMES clang-format clang-format-11)
 add_custom_target(ppr-format-check
   COMMAND find
     ${CMAKE_CURRENT_SOURCE_DIR}/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.14 AS build
 
-RUN apk add --no-cache build-base cmake ninja git linux-headers gcompat
+RUN apk add --no-cache build-base cmake ninja git linux-headers
 
 COPY . /src/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,12 @@
-FROM ubuntu:20.04 AS build
+FROM alpine:3.14 AS build
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -qq \
-      --no-install-recommends \
-      apt-transport-https \
-      ca-certificates \
-      git \
-      gnupg \
-      ninja-build \
-      software-properties-common \
-      wget \
-  && wget -nv -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
-  && add-apt-repository \
-      "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main" \
-  && wget -nv -O - https://apt.kitware.com/keys/kitware-archive-latest.asc \
-      | gpg --dearmor - \
-      | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null \
-  && apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main' \
-  && apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -qq \
-      --no-install-recommends \
-      clang-11 \
-      cmake \
-      libc++-11-dev \
-      libc++abi-11-dev \
-  && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache build-base cmake ninja git linux-headers
 
 COPY . /src/
 
 RUN mkdir /build \
   && cmake \
-      -GNinja -S /src -B /build \
-      -DCMAKE_C_COMPILER=/usr/bin/clang-11 \
-      -DCMAKE_CXX_COMPILER=/usr/bin/clang++-11 \
-      -DCMAKE_CXX_FLAGS="-stdlib=libc++" \
+      -G Ninja -S /src -B /build \
       -DCMAKE_BUILD_TYPE=Release \
       -DNO_BUILDCACHE=ON \
   && cmake \
@@ -47,30 +19,11 @@ RUN mkdir /build \
   && rm -rf /build
 
 
+FROM alpine:3.14
 
-FROM ubuntu:20.04
-
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -qq \
-      --no-install-recommends \
-      gnupg \
-      software-properties-common \
-      wget \
-  && wget -nv -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
-  && add-apt-repository \
-      "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main" \
-  && apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -qq \
-      --no-install-recommends \
-      libc++1-11 \
-      libc++abi1-11 \
-  && DEBIAN_FRONTEND=noninteractive apt-get purge --auto-remove -y \
-      gnupg \
-      software-properties-common \
-      wget \
-  && rm -rf /var/lib/apt/lists/* \
-  && useradd --user-group --create-home --shell /bin/bash ppr
+RUN apk add --no-cache libstdc++ \
+  && addgroup -S ppr \
+  && adduser -S ppr -G ppr
 
 COPY --from=build /ppr /ppr
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.14 AS build
 
-RUN apk add --no-cache build-base cmake ninja git linux-headers
+RUN apk add --no-cache build-base cmake ninja git linux-headers gcompat
 
 COPY . /src/
 

--- a/cmake/pkg.cmake
+++ b/cmake/pkg.cmake
@@ -26,7 +26,11 @@ message(STATUS "${pkg-bin} -l -h -f")
 execute_process(
   COMMAND ${pkg-bin} -l -h -f
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  RESULT_VARIABLE pkg-result
 )
+if (NOT pkg-result EQUAL 0)
+  message(FATAL_ERROR "pkg failed: ${pkg-result}")
+endif ()
 
 if (IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/deps")
   add_subdirectory(deps)

--- a/ubuntu.Dockerfile
+++ b/ubuntu.Dockerfile
@@ -1,0 +1,83 @@
+FROM ubuntu:20.04 AS build
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -qq \
+      --no-install-recommends \
+      apt-transport-https \
+      ca-certificates \
+      git \
+      gnupg \
+      ninja-build \
+      software-properties-common \
+      wget \
+  && wget -nv -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
+  && add-apt-repository \
+      "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main" \
+  && wget -nv -O - https://apt.kitware.com/keys/kitware-archive-latest.asc \
+      | gpg --dearmor - \
+      | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null \
+  && apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main' \
+  && apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -qq \
+      --no-install-recommends \
+      clang-11 \
+      cmake \
+      libc++-11-dev \
+      libc++abi-11-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY . /src/
+
+RUN mkdir /build \
+  && cmake \
+      -GNinja -S /src -B /build \
+      -DCMAKE_C_COMPILER=/usr/bin/clang-11 \
+      -DCMAKE_CXX_COMPILER=/usr/bin/clang++-11 \
+      -DCMAKE_CXX_FLAGS="-stdlib=libc++" \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DNO_BUILDCACHE=ON \
+  && cmake \
+      --build /build \
+      --target ppr-preprocess ppr-backend \
+  && install -t /ppr -D \
+      /build/ppr-preprocess \
+      /build/ppr-backend \
+  && cp -r /src/ui /ppr/ \
+  && rm -rf /build
+
+
+
+FROM ubuntu:20.04
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -qq \
+      --no-install-recommends \
+      gnupg \
+      software-properties-common \
+      wget \
+  && wget -nv -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
+  && add-apt-repository \
+      "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main" \
+  && apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -qq \
+      --no-install-recommends \
+      libc++1-11 \
+      libc++abi1-11 \
+  && DEBIAN_FRONTEND=noninteractive apt-get purge --auto-remove -y \
+      gnupg \
+      software-properties-common \
+      wget \
+  && rm -rf /var/lib/apt/lists/* \
+  && useradd --user-group --create-home --shell /bin/bash ppr
+
+COPY --from=build /ppr /ppr
+
+WORKDIR /ppr
+USER ppr
+
+EXPOSE 8000
+VOLUME ["/data"]
+
+CMD ["/ppr/ppr-backend", "-c", "/data/config.ini"]


### PR DESCRIPTION
Use Alpine as the docker base image and compile using GCC. Reduces the size of the docker image from 100 MB to 26 MB.