### PR TITLE
Improve sidewalk preprocessing

### DIFF
--- a/src/preprocessing/osm/way_info.cc
+++ b/src/preprocessing/osm/way_info.cc
@@ -121,7 +121,10 @@ way_info get_highway_info(osmium::Way const& way, osmium::TagList const& tags,
       sidewalk_left = true;
       sidewalk_right = true;
     }
-    if (street == street_type::LIVING && !sidewalk_left && !sidewalk_right) {
+    if ((street == street_type::LIVING || street == street_type::RESIDENTIAL ||
+         street == street_type::SERVICE ||
+         street == street_type::UNCLASSIFIED) &&
+        !sidewalk_left && !sidewalk_right) {
       type = edge_type::FOOTWAY;
     }
   } else if (is_footway(street, tags)) {

--- a/src/preprocessing/osm/way_info.cc
+++ b/src/preprocessing/osm/way_info.cc
@@ -111,9 +111,9 @@ way_info get_highway_info(osmium::Way const& way, osmium::TagList const& tags,
         sidewalk_left = true;
       } else if (strcmp(sidewalk, "right") == 0) {
         sidewalk_right = true;
-      } else if (strcmp(sidewalk, "no") == 0 || strcmp(sidewalk, "none") == 0) {
+      } else if (strcmp(sidewalk, "separate") == 0) {
         return {};
-      } else {
+      } else if (strcmp(sidewalk, "no") != 0 && strcmp(sidewalk, "none") != 0) {
         sidewalk_left = true;
         sidewalk_right = true;
       }


### PR DESCRIPTION
In the current version, roads tagged with `sidewalk=no` or `none` are not included in the routing graph at all. This change fixes a bug that prevented `highway=living_street` from being included nonetheless (as apparently intended by the code) and extends this behaviour to `residential`, `service` and `unclassified` roads. Especially in rural areas, many residential roads with little traffic do not have sidewalks and excluding these roads would in some cases make whole residential areas inaccessible for the routing engine.

In addition, this change adds support for the tag `sidewalk=separate`, which means that the sidewalk(s) of the road are mapped as separate footpaths. In this case, these should be used instead, so the road itself shoud be ignored completely.