### PR TITLE
unchecked graph deserialization for production mode

### DIFF
--- a/include/ppr/serialization/mode.h
+++ b/include/ppr/serialization/mode.h
@@ -4,10 +4,18 @@
 
 namespace ppr {
 
-constexpr auto const SERIALIZATION_MODE =
-    cista::mode::WITH_INTEGRITY | cista::mode::WITH_VERSION;
+constexpr auto const SERIALIZATION_MODE = cista::mode::WITH_INTEGRITY |
+                                          cista::mode::WITH_VERSION
+#ifndef NDEBUG
+                                          | cista::mode::UNCHECKED
+#endif
+    ;
 
 constexpr auto const SERIALIZATION_MODE_SKIP_INTEGRITY =
-    cista::mode::SKIP_INTEGRITY | cista::mode::WITH_VERSION;
+    cista::mode::SKIP_INTEGRITY | cista::mode::WITH_VERSION
+#ifndef NDEBUG
+    | cista::mode::UNCHECKED
+#endif
+    ;
 
 }  // namespace ppr


### PR DESCRIPTION
for production purposes, integrity+version check are sufficient for development purposes, checks should be enabled