### PR TITLE
Fix and improve preprocessing of crossings

### DIFF
--- a/include/ppr/preprocessing/osm_graph/osm_node.h
+++ b/include/ppr/preprocessing/osm_graph/osm_node.h
@@ -24,8 +24,9 @@ struct osm_node {
         int_node_(nullptr) {}
 
   bool can_be_compressed() const {
-    return access_allowed_ && in_edges_.size() == 1 && out_edges_.size() == 1 &&
-           !area_outer_ && !elevator_;
+    return access_allowed_ && crossing_ == crossing_type::NONE &&
+           in_edges_.size() == 1 && out_edges_.size() == 1 && !area_outer_ &&
+           !elevator_;
   }
 
   std::vector<osm_edge*> all_edges() {

--- a/src/preprocessing/osm/crossing.cc
+++ b/src/preprocessing/osm/crossing.cc
@@ -25,8 +25,11 @@ crossing_type::crossing_type get_crossing_type(osmium::TagList const& tags) {
       return crossing_type::NONE;
     } else {
       // crossing=unmarked and unknown crossing types
-      return tags.has_tag("crossing:signals", "yes") ? crossing_type::SIGNALS
-                                                     : crossing_type::UNMARKED;
+      if (tags.has_tag("crossing:signals", "yes")) {
+        return crossing_type::SIGNALS;
+      }
+      return tags.has_tag("crossing:island", "yes") ? crossing_type::ISLAND
+                                                    : crossing_type::UNMARKED;
     }
   }
 

--- a/src/preprocessing/osm/crossing.cc
+++ b/src/preprocessing/osm/crossing.cc
@@ -35,7 +35,7 @@ crossing_type::crossing_type get_crossing_type(osmium::TagList const& tags) {
 
 crossing_type::crossing_type get_node_crossing_type(
     osmium::TagList const& tags) {
-  if (tags.has_tag("highway", "crossing")) {
+  if (tags.has_tag("highway", "crossing") || tags.has_key("crossing")) {
     return get_crossing_type(tags);
   } else {
     return crossing_type::NONE;


### PR DESCRIPTION
A bug introduced with #36 caused most crossings to be ignored. It also removed support for crossings tagged as `highway=traffic_signals` + `crossing=traffic_signals` (as used by some mappers, see https://wiki.openstreetmap.org/wiki/Tag:highway%3Dtraffic_signals#How_to_map_(new)).

This pull request fixes this and adds support for `crossing:island=yes` (on unmarked crossings).