### PR TITLE
More Accessibility Improvements

### DIFF
--- a/include/ppr/common/edge.h
+++ b/include/ppr/common/edge.h
@@ -46,6 +46,12 @@ struct edge_info {
            street_type_ == street_type::TRAM;
   }
 
+  inline bool is_signals_crossing_with_sound_or_vibration() const {
+    return crossing_type_ == crossing_type::SIGNALS &&
+           (traffic_signals_sound_ == tri_state::YES ||
+            traffic_signals_vibration_ == tri_state::YES);
+  }
+
   template <typename Ctx>
   friend void serialize(Ctx& /*ctx*/, edge_info const* /*ei*/,
                         cista::offset_t const /*o*/) {}

--- a/include/ppr/routing/route_steps.h
+++ b/include/ppr/routing/route_steps.h
@@ -42,6 +42,7 @@ struct route_step {
   automatic_door_type automatic_door_type_{automatic_door_type::UNKNOWN};
   tri_state traffic_signals_sound_{tri_state::UNKNOWN};
   tri_state traffic_signals_vibration_{tri_state::UNKNOWN};
+  std::optional<std::uint8_t> max_width_{};  // centimeters
 
   std::vector<location> path_;
 };

--- a/include/ppr/routing/search_profile.h
+++ b/include/ppr/routing/search_profile.h
@@ -9,11 +9,6 @@ namespace ppr::routing {
 enum class usage_restriction { ALLOWED, PENALIZED, FORBIDDEN };
 
 struct cost_coefficients {
-  constexpr cost_coefficients() = default;
-
-  explicit constexpr cost_coefficients(double c0, double c1 = 0, double c2 = 0)
-      : c0_(c0), c1_(c1), c2_(c2) {}
-
   double c0_{0};
   double c1_{0};
   double c2_{0};
@@ -29,62 +24,19 @@ inline constexpr double operator*(cost_coefficients const& c, int val) {
 }
 
 struct cost_factor {
-  constexpr cost_factor() = default;
-  explicit constexpr cost_factor(usage_restriction allowed)
-      : allowed_(allowed) {}
-
-  constexpr cost_factor(cost_coefficients const& duration,
-                        cost_coefficients const& accessiblity,
-                        usage_restriction allowed = usage_restriction::ALLOWED,
-                        double duration_penalty = 0,
-                        double accessibility_penalty = 0)
-      : duration_(duration),
-        accessibility_(accessiblity),
-        allowed_(allowed),
-        duration_penalty_(duration_penalty),
-        accessibility_penalty_(accessibility_penalty) {}
-
-  constexpr cost_factor(cost_coefficients&& duration,
-                        cost_coefficients&& accessibility,
-                        usage_restriction allowed = usage_restriction::ALLOWED,
-                        double duration_penalty = 0,
-                        double accessibility_penalty = 0)
-      : duration_(duration),
-        accessibility_(accessibility),
-        allowed_(allowed),
-        duration_penalty_(duration_penalty),
-        accessibility_penalty_(accessibility_penalty) {}
-
-  cost_coefficients duration_;
-  cost_coefficients accessibility_;
+  cost_coefficients duration_{};
+  cost_coefficients accessibility_{};
   usage_restriction allowed_{usage_restriction::ALLOWED};
   double duration_penalty_{0};  // s
   double accessibility_penalty_{0};
 };
 
 struct crossing_cost_factor {
-  constexpr crossing_cost_factor() = default;
-
-  constexpr crossing_cost_factor(cost_factor const& signals,
-                                 cost_factor const& marked,
-                                 cost_factor const& island,
-                                 cost_factor const& unmarked)
-      : signals_(signals),
-        marked_(marked),
-        island_(island),
-        unmarked_(unmarked) {}
-
-  constexpr crossing_cost_factor(cost_factor&& signals, cost_factor&& marked,
-                                 cost_factor&& island, cost_factor&& unmarked)
-      : signals_(signals),
-        marked_(marked),
-        island_(island),
-        unmarked_(unmarked) {}
-
-  cost_factor signals_;
-  cost_factor marked_;
-  cost_factor island_;
-  cost_factor unmarked_;
+  cost_factor signals_{};
+  cost_factor blind_signals_{};
+  cost_factor marked_{};
+  cost_factor island_{};
+  cost_factor unmarked_{};
 };
 
 struct door_type_factors {
@@ -132,44 +84,44 @@ struct search_profile {
   int divisions_accessibility_ = 0;
 
   crossing_cost_factor crossing_primary_{
-      {cost_coefficients{120}, {}},  // signals
-      {cost_coefficients{100}, {}},  // marked
-      {cost_coefficients{200}, {}},  // island
-      {cost_factor{{}, {}, usage_restriction::PENALIZED, 200, 0}},  // unmarked
+      .signals_ = {.duration_ = cost_coefficients{120}},
+      .blind_signals_ = {.duration_ = cost_coefficients{120}},
+      .marked_ = {.duration_ = cost_coefficients{100}},
+      .island_ = {.duration_ = cost_coefficients{200}},
+      .unmarked_ = {cost_factor{.allowed_ = usage_restriction::PENALIZED,
+                                .duration_penalty_ = 200}},
   };
   crossing_cost_factor crossing_secondary_{
-      {cost_coefficients{60}, {}},  // signals
-      {cost_coefficients{30}, {}},  // marked
-      {cost_coefficients{60}, {}},  // island
-      {cost_coefficients{100}, {}},  // unmarked
+      .signals_ = {.duration_ = cost_coefficients{60}},
+      .blind_signals_ = {.duration_ = cost_coefficients{60}},
+      .marked_ = {.duration_ = cost_coefficients{30}},
+      .island_ = {.duration_ = cost_coefficients{60}},
+      .unmarked_ = {.duration_ = cost_coefficients{100}},
   };
   crossing_cost_factor crossing_tertiary_{
-      {cost_coefficients{60}, {}},  // signals
-      {cost_coefficients{30}, {}},  // marked
-      {cost_coefficients{60}, {}},  // island
-      {cost_coefficients{100}, {}},  // unmarked
+      .signals_ = {.duration_ = cost_coefficients{60}},
+      .blind_signals_ = {.duration_ = cost_coefficients{60}},
+      .marked_ = {.duration_ = cost_coefficients{30}},
+      .island_ = {.duration_ = cost_coefficients{60}},
+      .unmarked_ = {.duration_ = cost_coefficients{100}},
   };
   crossing_cost_factor crossing_residential_{
-      {cost_coefficients{45}, {}},  // signals
-      {cost_coefficients{20}, {}},  // marked
-      {cost_coefficients{40}, {}},  // island
-      {cost_coefficients{30}, {}},  // unmarked
+      .signals_ = {.duration_ = cost_coefficients{45}},
+      .blind_signals_ = {.duration_ = cost_coefficients{45}},
+      .marked_ = {.duration_ = cost_coefficients{20}},
+      .island_ = {.duration_ = cost_coefficients{40}},
+      .unmarked_ = {.duration_ = cost_coefficients{30}},
   };
-  crossing_cost_factor crossing_service_{
-      {{}, {}},  // signals
-      {{}, {}},  // marked
-      {{}, {}},  // island
-      {{}, {}},  // unmarked
-  };
+  crossing_cost_factor crossing_service_{};
 
-  cost_factor crossing_rail_{cost_coefficients{60}, {}};
-  cost_factor crossing_tram_{cost_coefficients{30}, {}};
+  cost_factor crossing_rail_{.duration_ = cost_coefficients{60}};
+  cost_factor crossing_tram_{.duration_ = cost_coefficients{30}};
 
   cost_factor stairs_up_cost_{};
   cost_factor stairs_down_cost_{};
   cost_factor stairs_with_handrail_up_cost_{};
   cost_factor stairs_with_handrail_down_cost_{};
-  cost_factor elevator_cost_{cost_coefficients{60}, {}};
+  cost_factor elevator_cost_{.duration_ = cost_coefficients{60}};
   cost_factor escalator_cost_{};
   cost_factor moving_walkway_cost_{};
   cost_factor cycle_barrier_cost_{};

--- a/include/ppr/routing/search_profile.h
+++ b/include/ppr/routing/search_profile.h
@@ -88,8 +88,8 @@ struct search_profile {
       .blind_signals_ = {.duration_ = cost_coefficients{120}},
       .marked_ = {.duration_ = cost_coefficients{100}},
       .island_ = {.duration_ = cost_coefficients{200}},
-      .unmarked_ = {cost_factor{.allowed_ = usage_restriction::PENALIZED,
-                                .duration_penalty_ = 200}},
+      .unmarked_ = {.allowed_ = usage_restriction::PENALIZED,
+                    .duration_penalty_ = 200},
   };
   crossing_cost_factor crossing_secondary_{
       .signals_ = {.duration_ = cost_coefficients{60}},

--- a/profiles/default.json
+++ b/profiles/default.json
@@ -33,6 +33,21 @@
       "duration_penalty": 0,
       "accessibility_penalty": 0
     },
+    "blind_signals": {
+      "duration": [
+        120,
+        0,
+        0
+      ],
+      "accessibility": [
+        0,
+        0,
+        0
+      ],
+      "allowed": "allowed",
+      "duration_penalty": 0,
+      "accessibility_penalty": 0
+    },
     "marked": {
       "duration": [
         100,
@@ -81,6 +96,21 @@
   },
   "crossing_secondary": {
     "signals": {
+      "duration": [
+        60,
+        0,
+        0
+      ],
+      "accessibility": [
+        0,
+        0,
+        0
+      ],
+      "allowed": "allowed",
+      "duration_penalty": 0,
+      "accessibility_penalty": 0
+    },
+    "blind_signals": {
       "duration": [
         60,
         0,
@@ -157,6 +187,21 @@
       "duration_penalty": 0,
       "accessibility_penalty": 0
     },
+    "blind_signals": {
+      "duration": [
+        60,
+        0,
+        0
+      ],
+      "accessibility": [
+        0,
+        0,
+        0
+      ],
+      "allowed": "allowed",
+      "duration_penalty": 0,
+      "accessibility_penalty": 0
+    },
     "marked": {
       "duration": [
         30,
@@ -219,6 +264,21 @@
       "duration_penalty": 0,
       "accessibility_penalty": 0
     },
+    "blind_signals": {
+      "duration": [
+        45,
+        0,
+        0
+      ],
+      "accessibility": [
+        0,
+        0,
+        0
+      ],
+      "allowed": "allowed",
+      "duration_penalty": 0,
+      "accessibility_penalty": 0
+    },
     "marked": {
       "duration": [
         20,
@@ -267,6 +327,21 @@
   },
   "crossing_service": {
     "signals": {
+      "duration": [
+        0,
+        0,
+        0
+      ],
+      "accessibility": [
+        0,
+        0,
+        0
+      ],
+      "allowed": "allowed",
+      "duration_penalty": 0,
+      "accessibility_penalty": 0
+    },
+    "blind_signals": {
       "duration": [
         0,
         0,

--- a/src/backend/output/route_response.cc
+++ b/src/backend/output/route_response.cc
@@ -300,6 +300,13 @@ void write_step(Writer& writer, route_step const& step, int index,
   writer.String("traffic_signals_vibration");
   write_tri_state(writer, step.traffic_signals_vibration_);
 
+  writer.String("max_width");
+  if (step.max_width_) {
+    writer.Double(static_cast<double>(*step.max_width_) / 100.);
+  } else {
+    writer.Null();
+  }
+
   writer.String("index");
   writer.Int(index);
 

--- a/src/profiles/parse_search_profile.cc
+++ b/src/profiles/parse_search_profile.cc
@@ -71,6 +71,8 @@ inline void get_crossing_cost_factor(crossing_cost_factor& ccf, Val const& doc,
     auto const& val = doc[key];
     if (val.IsObject()) {
       get_cost_factor(ccf.signals_, val, "signals");
+      ccf.blind_signals_ = ccf.signals_;
+      get_cost_factor(ccf.blind_signals_, val, "blind_signals");
       get_cost_factor(ccf.marked_, val, "marked");
       get_cost_factor(ccf.island_, val, "island");
       get_cost_factor(ccf.unmarked_, val, "unmarked");

--- a/src/routing/route_steps.cc
+++ b/src/routing/route_steps.cc
@@ -84,6 +84,14 @@ std::vector<route_step> get_route_steps(route const& r) {
     step.traffic_signals_sound_ = e.traffic_signals_sound_;
     step.traffic_signals_vibration_ = e.traffic_signals_vibration_;
 
+    if (e.max_width_ != 0) {
+      if (step.max_width_) {
+        step.max_width_ = std::min(*step.max_width_, e.max_width_);
+      } else {
+        step.max_width_ = e.max_width_;
+      }
+    }
+
     for (auto const& loc : e.path_) {
       if (step.path_.empty() || step.path_.back() != loc) {
         step.path_.push_back(loc);

--- a/ui/web/js/profiles.js
+++ b/ui/web/js/profiles.js
@@ -33,6 +33,21 @@ var defaultSearchProfile = {
       "duration_penalty": 0,
       "accessibility_penalty": 0
     },
+    "blind_signals": {
+      "duration": [
+        120,
+        0,
+        0
+      ],
+      "accessibility": [
+        0,
+        0,
+        0
+      ],
+      "allowed": "allowed",
+      "duration_penalty": 0,
+      "accessibility_penalty": 0
+    },
     "marked": {
       "duration": [
         100,
@@ -81,6 +96,21 @@ var defaultSearchProfile = {
   },
   "crossing_secondary": {
     "signals": {
+      "duration": [
+        60,
+        0,
+        0
+      ],
+      "accessibility": [
+        0,
+        0,
+        0
+      ],
+      "allowed": "allowed",
+      "duration_penalty": 0,
+      "accessibility_penalty": 0
+    },
+    "blind_signals": {
       "duration": [
         60,
         0,
@@ -157,6 +187,21 @@ var defaultSearchProfile = {
       "duration_penalty": 0,
       "accessibility_penalty": 0
     },
+    "blind_signals": {
+      "duration": [
+        60,
+        0,
+        0
+      ],
+      "accessibility": [
+        0,
+        0,
+        0
+      ],
+      "allowed": "allowed",
+      "duration_penalty": 0,
+      "accessibility_penalty": 0
+    },
     "marked": {
       "duration": [
         30,
@@ -219,6 +264,21 @@ var defaultSearchProfile = {
       "duration_penalty": 0,
       "accessibility_penalty": 0
     },
+    "blind_signals": {
+      "duration": [
+        45,
+        0,
+        0
+      ],
+      "accessibility": [
+        0,
+        0,
+        0
+      ],
+      "allowed": "allowed",
+      "duration_penalty": 0,
+      "accessibility_penalty": 0
+    },
     "marked": {
       "duration": [
         20,
@@ -267,6 +327,21 @@ var defaultSearchProfile = {
   },
   "crossing_service": {
     "signals": {
+      "duration": [
+        0,
+        0,
+        0
+      ],
+      "accessibility": [
+        0,
+        0,
+        0
+      ],
+      "allowed": "allowed",
+      "duration_penalty": 0,
+      "accessibility_penalty": 0
+    },
+    "blind_signals": {
       "duration": [
         0,
         0,


### PR DESCRIPTION
- For entrances with both `door` and `automatic_door` types, the component-wise minimum cost factor is now used
- `max_width` is now included in the route steps as well - the value is the minimum `max_width` of the edges included in the step, or `null` if no edge has a maximum width value
- Added a new cost factor to crossing cost factors: `blind_signals` is used for traffic signals with sound and/or vibration, `signals` is used for traffic signals without sound and vibration. For backwards compatibility, missing `blind_signals` values are copied from the `signals` cost factor.

See #46 for more information