### PR TITLE
Support indoor doors

### DIFF
--- a/src/preprocessing/osm_graph/extractor.cc
+++ b/src/preprocessing/osm_graph/extractor.cc
@@ -73,7 +73,7 @@ struct extract_handler : public osmium::handler::Handler {
       node->max_width_ = get_max_width_as_cm(tags);
       stats_.n_elevators_++;
     }
-    if (tags.has_key("entrance")) {
+    if (tags.has_key("entrance") || tags.has_tag("indoor", "door")) {
       auto* node = get_node(n.id(), n.location());
       node->entrance_ = true;
       node->door_type_ = get_door_type(tags);

--- a/ui/web/js/L.Routing.PPR.js
+++ b/ui/web/js/L.Routing.PPR.js
@@ -173,7 +173,7 @@ L.Routing.PPR = L.Class.extend({
         case "elevator":
           return "Elevator";
         case "entrance": {
-          let text = "Entrance";
+          let text = "Entrance/Door";
           if (s.automatic_door_type && s.automatic_door_type !== "no") {
             text += " (automatic door)";
           } else if (s.door_type && s.door_type !== "no") {


### PR DESCRIPTION
Add support for indoor doors ([indoor=door](https://wiki.openstreetmap.org/wiki/Tag:indoor=door)). For now they are handled in exactly the same way as [entrances](https://wiki.openstreetmap.org/wiki/Key:entrance). Both entrances and indoor doors are called "entrances" in the output (edge/step type).