### PR TITLE
Crossing path improvements

### DIFF
--- a/src/preprocessing/build_routing_graph.cc
+++ b/src/preprocessing/build_routing_graph.cc
@@ -233,8 +233,9 @@ private:
           }
           if (n != nullptr) {
             auto& e1_path = e1.edge_->path_left_;
-            join_footpath_with_street(e1_path, e1.reverse_, e2_path,
-                                      e2.reverse_);
+            auto const intersection = join_footpath_with_street(
+                e1_path, e1.reverse_, e2_path, e2.reverse_);
+            n->location_ = to_location(intersection);
             set_node(ig_, e1, side_type::LEFT, n);
           }
           return true;

--- a/src/preprocessing/int_graph/path.cc
+++ b/src/preprocessing/int_graph/path.cc
@@ -318,10 +318,6 @@ merc join_footpath_with_street(std::vector<merc>& foot_path, bool foot_reverse,
   } else {
     foot_path = foot_path_orig;
   }
-  auto const& foot_end = foot_reverse ? foot_path.back() : foot_path.front();
-  if (foot_end != street_end) {
-    add_point_to_path(foot_path, street_end, foot_reverse);
-  }
 
   return intersection;
 }

--- a/src/preprocessing/osm/way_info.cc
+++ b/src/preprocessing/osm/way_info.cc
@@ -292,7 +292,7 @@ way_info get_railway_info(osmium::Way const& way, osmium::TagList const& tags,
 
   info->level_ = get_level(tags);
 
-  auto const width = 2.0;
+  auto const width = 0.1;
   auto const layer = get_layer(tags);
 
   return {info_idx, false, false, width, layer};


### PR DESCRIPTION
- Crossing a street was previously always done perpendicular to the street geometry. Now the geometry of the crossing footpath is used.
- Reduce width of rail + tram tracks. Improves path smoothness when there are multiple tram tracks in close proximity.

-> Should result in smoother paths when crossing streets
