### PR TITLE
CI Update

### DIFF
--- a/.github/actions/install-llvm/action.yml
+++ b/.github/actions/install-llvm/action.yml
@@ -9,15 +9,19 @@ inputs:
     description: 'Packages to install'
     required: false
     default: >
-      clang-16
-      clang-tools-16
-      clang-format-16
-      clang-tidy-16
-      libc++-16-dev
-      libc++abi-16-dev
-      libclang-common-16-dev
-      libclang-rt-16-dev
-      libunwind-16-dev
+      clang-VERSION
+      clang-tools-VERSION
+      clang-format-VERSION
+      clang-tidy-VERSION
+      libc++-VERSION-dev
+      libc++abi-VERSION-dev
+      libclang-common-VERSION-dev
+      libclang-rt-VERSION-dev
+      libunwind-VERSION-dev
+outputs:
+  version:
+    description: 'LLVM version'
+    value: ${{ inputs.version }}
 runs:
   using: "composite"
   steps:
@@ -51,9 +55,9 @@ runs:
       env:
         DEBIAN_FRONTEND: noninteractive
 
-    - run: |
-        sudo apt-get install -y --no-install-recommends \
-          ${{ inputs.packages }}
+    - run: >
+        sudo apt-get install -y --no-install-recommends
+        $(echo "${{ inputs.packages }}" | sed 's/VERSION/${{ inputs.version }}/g')
       shell: bash
       env:
         DEBIAN_FRONTEND: noninteractive

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,13 +23,13 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -37,7 +37,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             ghcr.io/${{ github.repository }}
@@ -51,7 +51,7 @@ jobs:
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           file: ubuntu.Dockerfile
           push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -26,11 +26,11 @@ jobs:
       - name: Install clang-format
         uses: ./.github/actions/install-llvm
         with:
-          version: $LLVM_VERSION
-          packages: clang-format-$LLVM_VERSION
+          version: ${{ env.LLVM_VERSION }}
+          packages: clang-format-${{ env.LLVM_VERSION }}
 
       - name: Format files
-        run: find src include -type f -a \( -name "*.cc" -o -name "*.h" \) -print0 | xargs -0 clang-format-$LLVM_VERSION -i
+        run: find src include -type f -a \( -name "*.cc" -o -name "*.h" \) -print0 | xargs -0 clang-format-${{ env.LLVM_VERSION }} -i
 
       - name: Check for differences
         run: |
@@ -59,39 +59,39 @@ jobs:
             cxxflags: -stdlib=libc++
             os: macos-14
             artifact: macos-arm64
-          - name: GCC $GCC_VERSION Release
-            cxx: g++-$GCC_VERSION
-            cc: gcc-$GCC_VERSION
+          - name: GCC ${{ env.GCC_VERSION }} Release
+            cxx: g++-${{ env.GCC_VERSION }}
+            cc: gcc-${{ env.GCC_VERSION }}
             mode: Release
             mimalloc: on
             os: ubuntu-latest
             artifact: linux
-          - name: GCC $GCC_VERSION Debug
-            cxx: g++-$GCC_VERSION
-            cc: gcc-$GCC_VERSION
+          - name: GCC ${{ env.GCC_VERSION }} Debug
+            cxx: g++-${{ env.GCC_VERSION }}
+            cc: gcc-${{ env.GCC_VERSION }}
             mode: Debug
             mimalloc: on
             os: ubuntu-latest
-          - name: Clang $LLVM_VERSION Release
-            cxx: clang++-$LLVM_VERSION
-            cc: clang-$LLVM_VERSION
+          - name: Clang ${{ env.LLVM_VERSION }} Release
+            cxx: clang++-${{ env.LLVM_VERSION }}
+            cc: clang-${{ env.LLVM_VERSION }}
             mode: Release
             mimalloc: on
             cxxflags: -stdlib=libc++
             ldflags: -lc++abi
             os: ubuntu-latest
           - name: Clang Tidy
-            cxx: clang++-$LLVM_VERSION
-            cc: clang-$LLVM_VERSION
+            cxx: clang++-${{ env.LLVM_VERSION }}
+            cc: clang-${{ env.LLVM_VERSION }}
             mode: Release
             mimalloc: on
             cxxflags: -stdlib=libc++
             ldflags: -lc++abi
             lint: true
             os: ubuntu-latest
-          - key: Clang $LLVM_VERSION Sanitizer
-            cxx: clang++-$LLVM_VERSION
-            cc: clang-$LLVM_VERSION
+          - key: Clang ${{ env.LLVM_VERSION }} Sanitizer
+            cxx: clang++-${{ env.LLVM_VERSION }}
+            cc: clang-${{ env.LLVM_VERSION }}
             mode: Release
             mimalloc: on
             cflags: -fsanitize=address,undefined -fno-omit-frame-pointer
@@ -120,7 +120,7 @@ jobs:
         if: ${{ !startsWith(matrix.config.os, 'macos-') && startsWith(matrix.config.cc, 'clang') }}
         uses: ./.github/actions/install-llvm
         with:
-          version: $LLVM_VERSION
+          version: ${{ env.LLVM_VERSION }}
 
       - name: Install ninja (Ubuntu)
         if: ${{ !startsWith(matrix.config.os, 'macos-') }}
@@ -133,7 +133,7 @@ jobs:
         run: brew install ninja
 
       - name: Install Valgrind
-        if: ${{ matrix.config.mode == 'Debug' && matrix.config.cc == 'gcc-$GCC_VERSION' }}
+        if: ${{ matrix.config.mode == 'Debug' && matrix.config.cc == 'gcc-${{ env.GCC_VERSION }}' }}
         env:
           DEBIAN_FRONTEND: noninteractive
         run: sudo apt-get install -y --no-install-recommends valgrind

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -13,10 +13,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  LLVM_VERSION: 16
-  GCC_VERSION: 12
-
 jobs:
   formatting:
     runs-on: ubuntu-latest
@@ -26,11 +22,11 @@ jobs:
       - name: Install clang-format
         uses: ./.github/actions/install-llvm
         with:
-          version: ${{ env.LLVM_VERSION }}
-          packages: clang-format-${{ env.LLVM_VERSION }}
+          version: 16
+          packages: clang-format-16
 
       - name: Format files
-        run: find src include -type f -a \( -name "*.cc" -o -name "*.h" \) -print0 | xargs -0 clang-format-${{ env.LLVM_VERSION }} -i
+        run: find src include -type f -a \( -name "*.cc" -o -name "*.h" \) -print0 | xargs -0 clang-format-16 -i
 
       - name: Check for differences
         run: |
@@ -59,39 +55,39 @@ jobs:
             cxxflags: -stdlib=libc++
             os: macos-14
             artifact: macos-arm64
-          - name: GCC ${{ env.GCC_VERSION }} Release
-            cxx: g++-${{ env.GCC_VERSION }}
-            cc: gcc-${{ env.GCC_VERSION }}
+          - name: GCC 12 Release
+            cxx: g++-12
+            cc: gcc-12
             mode: Release
             mimalloc: on
             os: ubuntu-latest
             artifact: linux
-          - name: GCC ${{ env.GCC_VERSION }} Debug
-            cxx: g++-${{ env.GCC_VERSION }}
-            cc: gcc-${{ env.GCC_VERSION }}
+          - name: GCC 12 Debug
+            cxx: g++-12
+            cc: gcc-12
             mode: Debug
             mimalloc: on
             os: ubuntu-latest
-          - name: Clang ${{ env.LLVM_VERSION }} Release
-            cxx: clang++-${{ env.LLVM_VERSION }}
-            cc: clang-${{ env.LLVM_VERSION }}
+          - name: Clang 16 Release
+            cxx: clang++-16
+            cc: clang-16
             mode: Release
             mimalloc: on
             cxxflags: -stdlib=libc++
             ldflags: -lc++abi
             os: ubuntu-latest
           - name: Clang Tidy
-            cxx: clang++-${{ env.LLVM_VERSION }}
-            cc: clang-${{ env.LLVM_VERSION }}
+            cxx: clang++-16
+            cc: clang-16
             mode: Release
             mimalloc: on
             cxxflags: -stdlib=libc++
             ldflags: -lc++abi
             lint: true
             os: ubuntu-latest
-          - key: Clang ${{ env.LLVM_VERSION }} Sanitizer
-            cxx: clang++-${{ env.LLVM_VERSION }}
-            cc: clang-${{ env.LLVM_VERSION }}
+          - key: Clang 16 Sanitizer
+            cxx: clang++-16
+            cc: clang-16
             mode: Release
             mimalloc: on
             cflags: -fsanitize=address,undefined -fno-omit-frame-pointer
@@ -120,7 +116,7 @@ jobs:
         if: ${{ !startsWith(matrix.config.os, 'macos-') && startsWith(matrix.config.cc, 'clang') }}
         uses: ./.github/actions/install-llvm
         with:
-          version: ${{ env.LLVM_VERSION }}
+          version: 16
 
       - name: Install ninja (Ubuntu)
         if: ${{ !startsWith(matrix.config.os, 'macos-') }}
@@ -133,7 +129,7 @@ jobs:
         run: brew install ninja
 
       - name: Install Valgrind
-        if: ${{ matrix.config.mode == 'Debug' && matrix.config.cc == 'gcc-${{ env.GCC_VERSION }}' }}
+        if: ${{ matrix.config.mode == 'Debug' && matrix.config.cc == 'gcc-12' }}
         env:
           DEBIAN_FRONTEND: noninteractive
         run: sudo apt-get install -y --no-install-recommends valgrind

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -13,6 +13,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  LLVM_VERSION: 16
+  GCC_VERSION: 12
+
 jobs:
   formatting:
     runs-on: ubuntu-latest
@@ -22,10 +26,11 @@ jobs:
       - name: Install clang-format
         uses: ./.github/actions/install-llvm
         with:
-          packages: clang-format-16
+          version: $LLVM_VERSION
+          packages: clang-format-$LLVM_VERSION
 
       - name: Format files
-        run: find src include -type f -a \( -name "*.cc" -o -name "*.h" \) -print0 | xargs -0 clang-format-16 -i
+        run: find src include -type f -a \( -name "*.cc" -o -name "*.h" \) -print0 | xargs -0 clang-format-$LLVM_VERSION -i
 
       - name: Check for differences
         run: |
@@ -46,39 +51,39 @@ jobs:
             cxxflags: -stdlib=libc++
             os: macos-latest
             artifact: macos
-          - name: GCC 12 Release
-            cxx: g++-12
-            cc: gcc-12
+          - name: GCC $GCC_VERSION Release
+            cxx: g++-$GCC_VERSION
+            cc: gcc-$GCC_VERSION
             mode: Release
             mimalloc: on
             os: ubuntu-latest
             artifact: linux
-          - name: GCC 12 Debug
-            cxx: g++-12
-            cc: gcc-12
+          - name: GCC $GCC_VERSION Debug
+            cxx: g++-$GCC_VERSION
+            cc: gcc-$GCC_VERSION
             mode: Debug
             mimalloc: on
             os: ubuntu-latest
-          - name: Clang 16 Release
-            cxx: clang++-16
-            cc: clang-16
+          - name: Clang $LLVM_VERSION Release
+            cxx: clang++-$LLVM_VERSION
+            cc: clang-$LLVM_VERSION
             mode: Release
             mimalloc: on
             cxxflags: -stdlib=libc++
             ldflags: -lc++abi
             os: ubuntu-latest
           - name: Clang Tidy
-            cxx: clang++-16
-            cc: clang-16
+            cxx: clang++-$LLVM_VERSION
+            cc: clang-$LLVM_VERSION
             mode: Release
             mimalloc: on
             cxxflags: -stdlib=libc++
             ldflags: -lc++abi
             lint: true
             os: ubuntu-latest
-          - key: Clang 16 Sanitizer
-            cxx: clang++-16
-            cc: clang-16
+          - key: Clang $LLVM_VERSION Sanitizer
+            cxx: clang++-$LLVM_VERSION
+            cc: clang-$LLVM_VERSION
             mode: Release
             mimalloc: on
             cflags: -fsanitize=address,undefined -fno-omit-frame-pointer
@@ -98,27 +103,29 @@ jobs:
 
       # ==== INSTALL ====
       - name: Update Packages
-        if: matrix.config.os != 'macos-latest'
+        if: !startsWith(matrix.config.os, 'macos-')
         env:
           DEBIAN_FRONTEND: noninteractive
         run: sudo apt-get update
 
       - name: Install LLVM
-        if: matrix.config.os != 'macos-latest' && matrix.config.cc == 'clang-16'
+        if: !startsWith(matrix.config.os, 'macos-') && startsWith(matrix.config.cc, 'clang')
         uses: ./.github/actions/install-llvm
+        with:
+          version: $LLVM_VERSION
 
       - name: Install ninja (Ubuntu)
-        if: matrix.config.os != 'macos-latest'
+        if: !startsWith(matrix.config.os, 'macos-')
         env:
           DEBIAN_FRONTEND: noninteractive
         run: sudo apt-get install -y --no-install-recommends ninja-build
 
       - name: Install ninja (macOS)
-        if: matrix.config.os == 'macos-latest'
+        if: startsWith(matrix.config.os, 'macos-')
         run: brew install ninja
 
       - name: Install Valgrind
-        if: matrix.config.mode == 'Debug' && matrix.config.cc == 'gcc-12'
+        if: matrix.config.mode == 'Debug' && matrix.config.cc == 'gcc-$GCC_VERSION'
         env:
           DEBIAN_FRONTEND: noninteractive
         run: sudo apt-get install -y --no-install-recommends valgrind
@@ -165,14 +172,14 @@ jobs:
 
       # ==== DISTRIBUTION ====
       - name: Strip Executables
-        if: matrix.config.mode == 'Release' && (matrix.config.cc == 'gcc-12' || matrix.config.os == 'macos-latest')
+        if: matrix.config.artifact != ''
         run: |
           strip build/ppr-preprocess
           strip build/ppr-backend
           strip build/footrouting
 
       - name: Create Distribution
-        if: matrix.config.mode == 'Release' && (matrix.config.cc == 'gcc-12' || matrix.config.os == 'macos-latest')
+        if: matrix.config.artifact != ''
         run: |
           mkdir ppr
           mv build/ppr-preprocess ppr
@@ -182,7 +189,7 @@ jobs:
           tar cjf ppr-${{ matrix.config.artifact }}.tar.bz2 ppr
 
       - name: Upload Distribution
-        if: matrix.config.mode == 'Release' && (matrix.config.cc == 'gcc-12' || matrix.config.os == 'macos-latest')
+        if: matrix.config.artifact != ''
         uses: actions/upload-artifact@v4
         with:
           name: ppr-${{ matrix.config.artifact }}
@@ -190,7 +197,7 @@ jobs:
 
       # ==== RELEASE ====
       - name: Upload Release
-        if: github.event.action == 'published' && matrix.config.mode == 'Release' && (matrix.config.cc == 'gcc-12' || matrix.config.os == 'macos-latest')
+        if: github.event.action == 'published' && matrix.config.artifact != ''
         uses: actions/upload-release-asset@v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -43,14 +43,22 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - name: macOS Release
+          - name: macOS x86_64 Release
             cxx: clang++
             cc: clang
             mode: Release
             mimalloc: on
             cxxflags: -stdlib=libc++
-            os: macos-latest
-            artifact: macos
+            os: macos-13
+            artifact: macos-x86_64
+          - name: macOS arm64 Release
+            cxx: clang++
+            cc: clang
+            mode: Release
+            mimalloc: on
+            cxxflags: -stdlib=libc++
+            os: macos-14
+            artifact: macos-arm64
           - name: GCC $GCC_VERSION Release
             cxx: g++-$GCC_VERSION
             cc: gcc-$GCC_VERSION

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -13,6 +13,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  LLVM_VERSION: 16
+  GCC_VERSION: 12
+
 jobs:
   formatting:
     runs-on: ubuntu-latest
@@ -22,11 +26,11 @@ jobs:
       - name: Install clang-format
         uses: ./.github/actions/install-llvm
         with:
-          version: 16
-          packages: clang-format-16
+          version: ${{ env.LLVM_VERSION }}
+          packages: clang-format-${{ env.LLVM_VERSION }}
 
       - name: Format files
-        run: find src include -type f -a \( -name "*.cc" -o -name "*.h" \) -print0 | xargs -0 clang-format-16 -i
+        run: find src include -type f -a \( -name "*.cc" -o -name "*.h" \) -print0 | xargs -0 clang-format-${{ env.LLVM_VERSION }} -i
 
       - name: Check for differences
         run: |
@@ -55,39 +59,39 @@ jobs:
             cxxflags: -stdlib=libc++
             os: macos-14
             artifact: macos-arm64
-          - name: GCC 12 Release
-            cxx: g++-12
-            cc: gcc-12
+          - name: GCC ${{ env.GCC_VERSION }} Release
+            cxx: g++-${{ env.GCC_VERSION }}
+            cc: gcc-${{ env.GCC_VERSION }}
             mode: Release
             mimalloc: on
             os: ubuntu-latest
             artifact: linux
-          - name: GCC 12 Debug
-            cxx: g++-12
-            cc: gcc-12
+          - name: GCC ${{ env.GCC_VERSION }} Debug
+            cxx: g++-${{ env.GCC_VERSION }}
+            cc: gcc-${{ env.GCC_VERSION }}
             mode: Debug
             mimalloc: on
             os: ubuntu-latest
-          - name: Clang 16 Release
-            cxx: clang++-16
-            cc: clang-16
+          - name: Clang ${{ env.LLVM_VERSION }} Release
+            cxx: clang++-${{ env.LLVM_VERSION }}
+            cc: clang-${{ env.LLVM_VERSION }}
             mode: Release
             mimalloc: on
             cxxflags: -stdlib=libc++
             ldflags: -lc++abi
             os: ubuntu-latest
           - name: Clang Tidy
-            cxx: clang++-16
-            cc: clang-16
+            cxx: clang++-${{ env.LLVM_VERSION }}
+            cc: clang-${{ env.LLVM_VERSION }}
             mode: Release
             mimalloc: on
             cxxflags: -stdlib=libc++
             ldflags: -lc++abi
             lint: true
             os: ubuntu-latest
-          - key: Clang 16 Sanitizer
-            cxx: clang++-16
-            cc: clang-16
+          - key: Clang ${{ env.LLVM_VERSION }} Sanitizer
+            cxx: clang++-${{ env.LLVM_VERSION }}
+            cc: clang-${{ env.LLVM_VERSION }}
             mode: Release
             mimalloc: on
             cflags: -fsanitize=address,undefined -fno-omit-frame-pointer
@@ -116,7 +120,7 @@ jobs:
         if: ${{ !startsWith(matrix.config.os, 'macos-') && startsWith(matrix.config.cc, 'clang') }}
         uses: ./.github/actions/install-llvm
         with:
-          version: 16
+          version: ${{ env.LLVM_VERSION }}
 
       - name: Install ninja (Ubuntu)
         if: ${{ !startsWith(matrix.config.os, 'macos-') }}
@@ -129,7 +133,7 @@ jobs:
         run: brew install ninja
 
       - name: Install Valgrind
-        if: ${{ matrix.config.mode == 'Debug' && matrix.config.cc == 'gcc-12' }}
+        if: ${{ matrix.config.mode == 'Debug' && matrix.config.cc == 'gcc-${{ env.GCC_VERSION }}' }}
         env:
           DEBIAN_FRONTEND: noninteractive
         run: sudo apt-get install -y --no-install-recommends valgrind

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -18,6 +18,15 @@ env:
   GCC_VERSION: 12
 
 jobs:
+  env-vars:
+    name: Get environment variables
+    runs-on: ubuntu-latest
+    outputs:
+      LLVM_VERSION: ${{ env.LLVM_VERSION }}
+      GCC_VERSION: ${{ env.GCC_VERSION }}
+    steps:
+      - run: echo "🤡 GitHub 🤡"
+
   formatting:
     runs-on: ubuntu-latest
     steps:
@@ -26,11 +35,11 @@ jobs:
       - name: Install clang-format
         uses: ./.github/actions/install-llvm
         with:
-          version: ${{ vars.LLVM_VERSION }}
-          packages: clang-format-${{ vars.LLVM_VERSION }}
+          version: ${{ env.LLVM_VERSION }}
+          packages: clang-format-${{ env.LLVM_VERSION }}
 
       - name: Format files
-        run: find src include -type f -a \( -name "*.cc" -o -name "*.h" \) -print0 | xargs -0 clang-format-${{ vars.LLVM_VERSION }} -i
+        run: find src include -type f -a \( -name "*.cc" -o -name "*.h" \) -print0 | xargs -0 clang-format-${{ env.LLVM_VERSION }} -i
 
       - name: Check for differences
         run: |
@@ -39,6 +48,8 @@ jobs:
 
   build:
     runs-on: ${{ matrix.config.os }}
+    needs:
+      - env-vars
     strategy:
       fail-fast: false
       matrix:
@@ -59,39 +70,39 @@ jobs:
             cxxflags: -stdlib=libc++
             os: macos-14
             artifact: macos-arm64
-          - name: GCC ${{ vars.GCC_VERSION }} Release
-            cxx: g++-${{ vars.GCC_VERSION }}
-            cc: gcc-${{ vars.GCC_VERSION }}
+          - name: GCC ${{ needs.env-vars.outputs.GCC_VERSION }} Release
+            cxx: g++-${{ needs.env-vars.outputs.GCC_VERSION }}
+            cc: gcc-${{ needs.env-vars.outputs.GCC_VERSION }}
             mode: Release
             mimalloc: on
             os: ubuntu-latest
             artifact: linux
-          - name: GCC ${{ vars.GCC_VERSION }} Debug
-            cxx: g++-${{ vars.GCC_VERSION }}
-            cc: gcc-${{ vars.GCC_VERSION }}
+          - name: GCC ${{ needs.env-vars.outputs.GCC_VERSION }} Debug
+            cxx: g++-${{ needs.env-vars.outputs.GCC_VERSION }}
+            cc: gcc-${{ needs.env-vars.outputs.GCC_VERSION }}
             mode: Debug
             mimalloc: on
             os: ubuntu-latest
-          - name: Clang ${{ vars.LLVM_VERSION }} Release
-            cxx: clang++-${{ vars.LLVM_VERSION }}
-            cc: clang-${{ vars.LLVM_VERSION }}
+          - name: Clang ${{ needs.env-vars.outputs.LLVM_VERSION }} Release
+            cxx: clang++-${{ needs.env-vars.outputs.LLVM_VERSION }}
+            cc: clang-${{ needs.env-vars.outputs.LLVM_VERSION }}
             mode: Release
             mimalloc: on
             cxxflags: -stdlib=libc++
             ldflags: -lc++abi
             os: ubuntu-latest
           - name: Clang Tidy
-            cxx: clang++-${{ vars.LLVM_VERSION }}
-            cc: clang-${{ vars.LLVM_VERSION }}
+            cxx: clang++-${{ needs.env-vars.outputs.LLVM_VERSION }}
+            cc: clang-${{ needs.env-vars.outputs.LLVM_VERSION }}
             mode: Release
             mimalloc: on
             cxxflags: -stdlib=libc++
             ldflags: -lc++abi
             lint: true
             os: ubuntu-latest
-          - key: Clang ${{ vars.LLVM_VERSION }} Sanitizer
-            cxx: clang++-${{ vars.LLVM_VERSION }}
-            cc: clang-${{ vars.LLVM_VERSION }}
+          - key: Clang ${{ needs.env-vars.outputs.LLVM_VERSION }} Sanitizer
+            cxx: clang++-${{ needs.env-vars.outputs.LLVM_VERSION }}
+            cc: clang-${{ needs.env-vars.outputs.LLVM_VERSION }}
             mode: Release
             mimalloc: on
             cflags: -fsanitize=address,undefined -fno-omit-frame-pointer
@@ -120,7 +131,7 @@ jobs:
         if: ${{ !startsWith(matrix.config.os, 'macos-') && startsWith(matrix.config.cc, 'clang') }}
         uses: ./.github/actions/install-llvm
         with:
-          version: ${{ vars.LLVM_VERSION }}
+          version: ${{ env.LLVM_VERSION }}
 
       - name: Install ninja (Ubuntu)
         if: ${{ !startsWith(matrix.config.os, 'macos-') }}
@@ -133,7 +144,7 @@ jobs:
         run: brew install ninja
 
       - name: Install Valgrind
-        if: ${{ matrix.config.mode == 'Debug' && matrix.config.cc == 'gcc-${{ vars.GCC_VERSION }}' }}
+        if: ${{ matrix.config.mode == 'Debug' && matrix.config.cc == 'gcc-${{ env.GCC_VERSION }}' }}
         env:
           DEBIAN_FRONTEND: noninteractive
         run: sudo apt-get install -y --no-install-recommends valgrind

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -111,29 +111,29 @@ jobs:
 
       # ==== INSTALL ====
       - name: Update Packages
-        if: !startsWith(matrix.config.os, 'macos-')
+        if: ${{ !startsWith(matrix.config.os, 'macos-') }}
         env:
           DEBIAN_FRONTEND: noninteractive
         run: sudo apt-get update
 
       - name: Install LLVM
-        if: !startsWith(matrix.config.os, 'macos-') && startsWith(matrix.config.cc, 'clang')
+        if: ${{ !startsWith(matrix.config.os, 'macos-') && startsWith(matrix.config.cc, 'clang') }}
         uses: ./.github/actions/install-llvm
         with:
           version: $LLVM_VERSION
 
       - name: Install ninja (Ubuntu)
-        if: !startsWith(matrix.config.os, 'macos-')
+        if: ${{ !startsWith(matrix.config.os, 'macos-') }}
         env:
           DEBIAN_FRONTEND: noninteractive
         run: sudo apt-get install -y --no-install-recommends ninja-build
 
       - name: Install ninja (macOS)
-        if: startsWith(matrix.config.os, 'macos-')
+        if: ${{ startsWith(matrix.config.os, 'macos-') }}
         run: brew install ninja
 
       - name: Install Valgrind
-        if: matrix.config.mode == 'Debug' && matrix.config.cc == 'gcc-$GCC_VERSION'
+        if: ${{ matrix.config.mode == 'Debug' && matrix.config.cc == 'gcc-$GCC_VERSION' }}
         env:
           DEBIAN_FRONTEND: noninteractive
         run: sudo apt-get install -y --no-install-recommends valgrind

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -17,7 +17,7 @@ jobs:
   formatting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install clang-format
         uses: ./.github/actions/install-llvm
@@ -94,7 +94,7 @@ jobs:
       UBSAN_OPTIONS: halt_on_error=1:abort_on_error=1
       CLICOLOR_FORCE: 1
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # ==== INSTALL ====
       - name: Update Packages
@@ -125,7 +125,7 @@ jobs:
 
       # ==== RESTORE CACHE ====
       - name: Restore buildcache Cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         id: restore-buildcache
         with:
           path: ${{ github.workspace }}/.buildcache
@@ -136,7 +136,7 @@ jobs:
             buildcache-${{ matrix.config.os }}-${{ matrix.config.cc }}-${{ matrix.config.mode }}-${{ contains(matrix.config.cxxflags, 'sanitize') }}-${{ matrix.config.lint }}-
 
       - name: Restore Dependencies Cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         id: restore-deps-cache
         with:
           path: ${{ github.workspace }}/deps
@@ -183,7 +183,7 @@ jobs:
 
       - name: Upload Distribution
         if: matrix.config.mode == 'Release' && (matrix.config.cc == 'gcc-12' || matrix.config.os == 'macos-latest')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ppr-${{ matrix.config.artifact }}
           path: ppr-${{ matrix.config.artifact }}.tar.bz2
@@ -202,15 +202,15 @@ jobs:
 
       # ==== SAVE CACHE ====
       - name: Save buildcache Cache
-        if: always()
-        uses: actions/cache/save@v3
+        if: always() && steps.restore-buildcache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
         with:
           path: ${{ github.workspace }}/.buildcache
           key: ${{ steps.restore-buildcache.outputs.cache-primary-key }}
 
       - name: Save Dependencies Cache
-        if: always()
-        uses: actions/cache/save@v3
+        if: always() && steps.restore-deps-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
         with:
           path: ${{ github.workspace }}/deps
           key: ${{ steps.restore-deps-cache.outputs.cache-primary-key }}

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -26,11 +26,11 @@ jobs:
       - name: Install clang-format
         uses: ./.github/actions/install-llvm
         with:
-          version: ${{ env.LLVM_VERSION }}
-          packages: clang-format-${{ env.LLVM_VERSION }}
+          version: ${{ vars.LLVM_VERSION }}
+          packages: clang-format-${{ vars.LLVM_VERSION }}
 
       - name: Format files
-        run: find src include -type f -a \( -name "*.cc" -o -name "*.h" \) -print0 | xargs -0 clang-format-${{ env.LLVM_VERSION }} -i
+        run: find src include -type f -a \( -name "*.cc" -o -name "*.h" \) -print0 | xargs -0 clang-format-${{ vars.LLVM_VERSION }} -i
 
       - name: Check for differences
         run: |
@@ -59,39 +59,39 @@ jobs:
             cxxflags: -stdlib=libc++
             os: macos-14
             artifact: macos-arm64
-          - name: GCC ${{ env.GCC_VERSION }} Release
-            cxx: g++-${{ env.GCC_VERSION }}
-            cc: gcc-${{ env.GCC_VERSION }}
+          - name: GCC ${{ vars.GCC_VERSION }} Release
+            cxx: g++-${{ vars.GCC_VERSION }}
+            cc: gcc-${{ vars.GCC_VERSION }}
             mode: Release
             mimalloc: on
             os: ubuntu-latest
             artifact: linux
-          - name: GCC ${{ env.GCC_VERSION }} Debug
-            cxx: g++-${{ env.GCC_VERSION }}
-            cc: gcc-${{ env.GCC_VERSION }}
+          - name: GCC ${{ vars.GCC_VERSION }} Debug
+            cxx: g++-${{ vars.GCC_VERSION }}
+            cc: gcc-${{ vars.GCC_VERSION }}
             mode: Debug
             mimalloc: on
             os: ubuntu-latest
-          - name: Clang ${{ env.LLVM_VERSION }} Release
-            cxx: clang++-${{ env.LLVM_VERSION }}
-            cc: clang-${{ env.LLVM_VERSION }}
+          - name: Clang ${{ vars.LLVM_VERSION }} Release
+            cxx: clang++-${{ vars.LLVM_VERSION }}
+            cc: clang-${{ vars.LLVM_VERSION }}
             mode: Release
             mimalloc: on
             cxxflags: -stdlib=libc++
             ldflags: -lc++abi
             os: ubuntu-latest
           - name: Clang Tidy
-            cxx: clang++-${{ env.LLVM_VERSION }}
-            cc: clang-${{ env.LLVM_VERSION }}
+            cxx: clang++-${{ vars.LLVM_VERSION }}
+            cc: clang-${{ vars.LLVM_VERSION }}
             mode: Release
             mimalloc: on
             cxxflags: -stdlib=libc++
             ldflags: -lc++abi
             lint: true
             os: ubuntu-latest
-          - key: Clang ${{ env.LLVM_VERSION }} Sanitizer
-            cxx: clang++-${{ env.LLVM_VERSION }}
-            cc: clang-${{ env.LLVM_VERSION }}
+          - key: Clang ${{ vars.LLVM_VERSION }} Sanitizer
+            cxx: clang++-${{ vars.LLVM_VERSION }}
+            cc: clang-${{ vars.LLVM_VERSION }}
             mode: Release
             mimalloc: on
             cflags: -fsanitize=address,undefined -fno-omit-frame-pointer
@@ -120,7 +120,7 @@ jobs:
         if: ${{ !startsWith(matrix.config.os, 'macos-') && startsWith(matrix.config.cc, 'clang') }}
         uses: ./.github/actions/install-llvm
         with:
-          version: ${{ env.LLVM_VERSION }}
+          version: ${{ vars.LLVM_VERSION }}
 
       - name: Install ninja (Ubuntu)
         if: ${{ !startsWith(matrix.config.os, 'macos-') }}
@@ -133,7 +133,7 @@ jobs:
         run: brew install ninja
 
       - name: Install Valgrind
-        if: ${{ matrix.config.mode == 'Debug' && matrix.config.cc == 'gcc-${{ env.GCC_VERSION }}' }}
+        if: ${{ matrix.config.mode == 'Debug' && matrix.config.cc == 'gcc-${{ vars.GCC_VERSION }}' }}
         env:
           DEBIAN_FRONTEND: noninteractive
         run: sudo apt-get install -y --no-install-recommends valgrind

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -77,20 +77,18 @@ jobs:
       # ==== DISTRIBUTION ====
       - name: Create Distribution
         if: matrix.mode == 'Release'
-        run: >
-          7z a ppr-windows.zip
-          .\build\ppr-preprocess.exe
-          .\build\ppr-backend.exe
-          .\build\footrouting.exe
-          .\build\*.dll
-          .\ui\web
+        run: |
+          mkdir dist
+          mv .\build\*.exe dist
+          mv .\build\*.dll dist
+          mv .\ui\web dist
 
       - name: Upload Distribution
         if: matrix.mode == 'Release'
         uses: actions/upload-artifact@v4
         with:
           name: ppr-windows
-          path: ppr-windows.zip
+          path: dist
 
       # ==== RELEASE ====
       - name: Upload Release

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -33,14 +33,14 @@ jobs:
       CLICOLOR_FORCE: 1
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install ninja
         run: choco install ninja
 
       # ==== RESTORE CACHE ====
       - name: Restore buildcache Cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         id: restore-buildcache
         with:
           path: ${{ github.workspace }}/.buildcache
@@ -51,7 +51,7 @@ jobs:
             buildcache-windows-${{ matrix.mode }}-
 
       - name: Restore Dependencies Cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         id: restore-deps-cache
         with:
           path: ${{ github.workspace }}/deps
@@ -87,7 +87,7 @@ jobs:
 
       - name: Upload Distribution
         if: matrix.mode == 'Release'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ppr-windows
           path: ppr-windows.zip
@@ -106,15 +106,15 @@ jobs:
 
       # ==== SAVE CACHE ====
       - name: Save buildcache Cache
-        if: always()
-        uses: actions/cache/save@v3
+        if: always() && steps.restore-buildcache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
         with:
           path: ${{ github.workspace }}/.buildcache
           key: ${{ steps.restore-buildcache.outputs.cache-primary-key }}
 
       - name: Save Dependencies Cache
-        if: always()
-        uses: actions/cache/save@v3
+        if: always() && steps.restore-deps-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
         with:
           path: ${{ github.workspace }}/deps
           key: ${{ steps.restore-deps-cache.outputs.cache-primary-key }}


### PR DESCRIPTION
- New action versions to fix deprecation warnings:
	- [GitHub Actions: Transitioning from Node 16 to Node 20 - The GitHub Blog](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)
	- [Deprecation notice: v1 and v2 of the artifact actions - The GitHub Blog](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/)
- New macOS arm64 build (using the `macos-14` runner)
- CI Refactoring