### PR TITLE
Add highway=corridor to footway types

### DIFF
--- a/include/ppr/common/enums.h
+++ b/include/ppr/common/enums.h
@@ -32,6 +32,7 @@ enum class street_type : std::uint8_t {
   FOOTWAY,
   PATH,
   CYCLEWAY,
+  CORRIDOR,
   BRIDLEWAY,
   STAIRS,
   ESCALATOR,

--- a/include/ppr/output/geojson/edge_info.h
+++ b/include/ppr/output/geojson/edge_info.h
@@ -74,6 +74,7 @@ void write_street_type(Writer& writer, street_type const type) {
     case street_type::FOOTWAY: writer.String("footway"); break;
     case street_type::PATH: writer.String("path"); break;
     case street_type::CYCLEWAY: writer.String("cycleway"); break;
+    case street_type::CORRIDOR: writer.String("corridor"); break;
     case street_type::BRIDLEWAY: writer.String("bridleway"); break;
     case street_type::STAIRS: writer.String("stairs"); break;
     case street_type::ESCALATOR: writer.String("escalator"); break;

--- a/src/backend/output/route_response.cc
+++ b/src/backend/output/route_response.cc
@@ -64,6 +64,7 @@ char const* street_type_str(street_type const street) {
     case street_type::FOOTWAY: return "footway";
     case street_type::PATH: return "path";
     case street_type::CYCLEWAY: return "cycleway";
+    case street_type::CORRIDOR: return "corridor";
     case street_type::BRIDLEWAY: return "bridleway";
     case street_type::STAIRS: return "stairs";
     case street_type::ESCALATOR: return "escalator";

--- a/src/preprocessing/osm/way_info.cc
+++ b/src/preprocessing/osm/way_info.cc
@@ -32,7 +32,7 @@ bool is_footway(street_type const street, osmium::TagList const& tags) {
   }
   return street == street_type::TRACK || street == street_type::FOOTWAY ||
          street == street_type::PATH || street == street_type::PEDESTRIAN ||
-         street == street_type::STAIRS;
+         street == street_type::STAIRS || street == street_type::CORRIDOR;
 }
 
 street_type get_street_type(char const* highway) {
@@ -55,6 +55,8 @@ street_type get_street_type(char const* highway) {
     return street_type::PATH;
   } else if (strcmp(highway, "cycleway") == 0) {
     return street_type::CYCLEWAY;
+  } else if (strcmp(highway, "corridor") == 0) {
+    return street_type::CORRIDOR;
   } else if (strcmp(highway, "bridleway") == 0) {
     return street_type::BRIDLEWAY;
   } else if (strcmp(highway, "tertiary") == 0 ||


### PR DESCRIPTION
Some mappers prefer using [highway=corridor](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dcorridor) to map indoor paths as an alternative to `highway=footway/path`. These ways are currently not included in the PPR graph.

Example usage: Dresden main station (https://www.openstreetmap.org/way/266304460)

**Warning:** I haven't tested the code yet.