### PR TITLE
Use buffered area polygon for extended visibility graphs

### DIFF
--- a/include/ppr/common/area.h
+++ b/include/ppr/common/area.h
@@ -16,6 +16,19 @@
 
 namespace ppr {
 
+inline area_polygon_t get_buffered_polygon(area_polygon_t const& input) {
+  auto const distance_strategy =
+      boost::geometry::strategy::buffer::distance_symmetric<double>{0.5};
+  auto const join_strategy = boost::geometry::strategy::buffer::join_miter{};
+  auto const end_strategy = boost::geometry::strategy::buffer::end_flat{};
+  auto const point_strategy = boost::geometry::strategy::buffer::point_square{};
+  auto const side_strategy = boost::geometry::strategy::buffer::side_straight{};
+  auto output = area_multipolygon_t{};
+  boost::geometry::buffer(input, output, distance_strategy, side_strategy,
+                          join_strategy, end_strategy, point_strategy);
+  return output[0];
+}
+
 struct area {
   struct point {
     merc get_merc() const { return to_merc(location_); }
@@ -61,9 +74,10 @@ struct area {
     return polygon_.inners();
   }
 
-  area_polygon_t get_outer_polygon() const {
+  area_polygon_t get_outer_polygon(bool const buffered = false) const {
     auto const points = get_ring_points(polygon_.outer());
-    return {{begin(points), end(points)}};
+    auto poly = area_polygon_t{{begin(points), end(points)}};
+    return buffered ? get_buffered_polygon(poly) : poly;
   }
 
   std::vector<inner_area_polygon_t> get_inner_polygons() const {

--- a/include/ppr/common/area.h
+++ b/include/ppr/common/area.h
@@ -16,14 +16,15 @@
 
 namespace ppr {
 
-inline area_polygon_t get_buffered_polygon(area_polygon_t const& input) {
+template <typename T>
+inline T get_buffered_polygon(T const& input, double const distance = 0.5) {
   auto const distance_strategy =
-      boost::geometry::strategy::buffer::distance_symmetric<double>{0.5};
+      boost::geometry::strategy::buffer::distance_symmetric<double>{distance};
   auto const join_strategy = boost::geometry::strategy::buffer::join_miter{};
   auto const end_strategy = boost::geometry::strategy::buffer::end_flat{};
   auto const point_strategy = boost::geometry::strategy::buffer::point_square{};
   auto const side_strategy = boost::geometry::strategy::buffer::side_straight{};
-  auto output = area_multipolygon_t{};
+  auto output = boost::geometry::model::multi_polygon<T>{};
   boost::geometry::buffer(input, output, distance_strategy, side_strategy,
                           join_strategy, end_strategy, point_strategy);
   return output[0];
@@ -80,12 +81,14 @@ struct area {
     return buffered ? get_buffered_polygon(poly) : poly;
   }
 
-  std::vector<inner_area_polygon_t> get_inner_polygons() const {
+  std::vector<inner_area_polygon_t> get_inner_polygons(
+      bool const buffered = false) const {
     std::vector<inner_area_polygon_t> obstacles;
     for (auto const& inner : polygon_.inners()) {
       auto const points = get_ring_points(inner);
-      obstacles.emplace_back(
-          inner_area_polygon_t{{begin(points), end(points)}});
+      auto poly = inner_area_polygon_t{{begin(points), end(points)}};
+      obstacles.emplace_back(buffered ? get_buffered_polygon(poly, -0.1)
+                                      : poly);
     }
     return obstacles;
   }

--- a/include/ppr/common/area_routing.h
+++ b/include/ppr/common/area_routing.h
@@ -125,8 +125,7 @@ void calc_visiblity(visibility_graph<Area>& vg,
     }
     auto seg = merc_linestring_t{{a_loc, b_loc}};
     shorten_segment(seg, 0.5);
-    if (!boost::geometry::within(seg,
-                                 outer_polygon)) {
+    if (!boost::geometry::within(seg, outer_polygon)) {
       continue;
     }
     auto visible = true;

--- a/include/ppr/common/area_routing.h
+++ b/include/ppr/common/area_routing.h
@@ -164,7 +164,7 @@ visibility_graph<Area> extend_visibility_graph(
     std::vector<typename Area::point_type>& additional_points) {
   visibility_graph<Area> vg(area, additional_points);
   auto const outer_polygon = area->get_outer_polygon(true);
-  auto const obstacles = area->get_inner_polygons();
+  auto const obstacles = area->get_inner_polygons(true);
 
   for (auto i = vg.base_size_; i < vg.n_; i++) {
     calc_visiblity(vg, outer_polygon, obstacles, i, 0);

--- a/include/ppr/common/geometry/polygon.h
+++ b/include/ppr/common/geometry/polygon.h
@@ -6,5 +6,7 @@ namespace ppr {
 
 using area_polygon_t = boost::geometry::model::polygon<merc, false>;
 using inner_area_polygon_t = boost::geometry::model::polygon<merc, true>;
+using area_multipolygon_t =
+    boost::geometry::model::multi_polygon<area_polygon_t>;
 
 }  // namespace ppr

--- a/include/ppr/common/geometry/polygon.h
+++ b/include/ppr/common/geometry/polygon.h
@@ -6,7 +6,5 @@ namespace ppr {
 
 using area_polygon_t = boost::geometry::model::polygon<merc, false>;
 using inner_area_polygon_t = boost::geometry::model::polygon<merc, true>;
-using area_multipolygon_t =
-    boost::geometry::model::multi_polygon<area_polygon_t>;
 
 }  // namespace ppr


### PR DESCRIPTION
Fixes an issue with area routing if start and/or destination points are close to an area.

When a segment (in the example: the segment between the two points where the red linestring crosses the platform area) is on the outer polygon of the area, the visibility check sometimes didn't work, resulting in crazy routes through the area.

To fix this, we now use a [buffer](https://www.boost.org/doc/libs/1_84_0/libs/geometry/doc/html/geometry/reference/algorithms/buffer/buffer_7_with_strategies.html) of the outer polygon for visibility checks when extending the visibility graph.

Before:
![chrome_2024-03-07_16-29-31](https://github.com/motis-project/ppr/assets/996199/6ad7dbb6-4da8-4508-be22-856e5870a5dc)

After:
![chrome_2024-03-07_16-29-40](https://github.com/motis-project/ppr/assets/996199/20a47f7c-4288-4209-a03f-f25679590eab)

(Only the gray platform is an area in this example.)

The same problem occured with inner polygons:

Before:
![chrome_2024-03-07_17-12-01](https://github.com/motis-project/ppr/assets/996199/7a71a57e-9710-48a6-9711-596db0d05f68)

After:
![chrome_2024-03-07_17-12-30](https://github.com/motis-project/ppr/assets/996199/586c87ab-fe05-404e-be68-dbd2782f15a5)
